### PR TITLE
Added pre-install step for wheel and cmake 3.18.4

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Wheel is never depended on, but always needed. MulticoreTSNE requires lower CMake version
+pip install wheel cmake==3.18.4
+
 cd calvin_env/tacto
 pip install -e .
 cd ..


### PR DESCRIPTION
Pull request to fix issue #17. I opted to add an additional install command to the `install.sh` instead of adding it to the package dependencies in order to guarantee that this hidden dependency is satisfied when the dependent packages are being installed.