### PR TITLE
Expanded .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,9 @@ dataset/task_ABCD_D/*
 dataset/task_ABC_D/*
 
 .idea/*
+
+# Ignore venv created as part of installation instructions
+calvin_venv/*
+
+# Ignore datasets as downloaded according to instructions
+dataset/*


### PR DESCRIPTION
The ignore file does not cover the virtual environment and dataset downloaded as a part of the instructions. That's a bit annoying, when looking at the files in `git gui`.