### PR TITLE
Simple script to visualize and run through data from a CALVIN dataset.

### DIFF
--- a/scripts/visualize_dataset.py
+++ b/scripts/visualize_dataset.py
@@ -26,9 +26,9 @@ if __name__ == '__main__':
             if d not in t:
                 print(f'Data {d} cannot be found in transition')
                 continue
-            
+
             cv2.imshow(d, t[d])
-        
+
         key = cv2.waitKey(0)
         if key == ord('q'):
             break

--- a/scripts/visualize_dataset.py
+++ b/scripts/visualize_dataset.py
@@ -32,9 +32,9 @@ if __name__ == '__main__':
         key = cv2.waitKey(0)
         if key == ord('q'):
             break
-        elif key == 83: #  Right arrow or p
+        elif key == 83:  # Right arrow
             idx = (idx + 1) % len(files)
-        elif key == 81: #  Left arrow or o
+        elif key == 81:  # Left arrow
             idx = (len(files) + idx - 1) % len(files)
         else:
             print(f'Unrecognized keycode "{key}"')

--- a/scripts/visualize_dataset.py
+++ b/scripts/visualize_dataset.py
@@ -15,26 +15,37 @@ if __name__ == '__main__':
         print(f'Path {args.path} is either not a directory, or does not exist.')
         exit()
 
-    files = sorted(Path(args.path).glob('episode_*.npz'))
+    indices = next(iter(np.load(f'{args.path}/scene_info.npy', allow_pickle=True).item().values()))
+    indices = list(range(indices[0], indices[1] + 1))
+    
+    annotations = np.load(f'{args.path}/lang_annotations/auto_lang_ann.npy', allow_pickle=True).item()
+    annotations = list(zip(annotations['info']['indx'], annotations['language']['ann']))
 
     idx = 0
+    ann_idx = -1
 
     while True:
-        t = np.load(files[idx], allow_pickle=True)
+        t = np.load(f'{args.path}/episode_{indices[idx]:07d}.npz', allow_pickle=True)
 
         for d in args.data:
             if d not in t:
                 print(f'Data {d} cannot be found in transition')
                 continue
 
-            cv2.imshow(d, t[d])
+            cv2.imshow(d, t[d][:,:,::-1])
+
+        for n, ((low, high), ann) in enumerate(annotations):
+            if indices[idx] >= low and indices[idx] <= high:
+                if n != ann_idx:
+                    print(f'{ann}')
+                    ann_idx = n
 
         key = cv2.waitKey(0)
         if key == ord('q'):
             break
         elif key == 83:  # Right arrow
-            idx = (idx + 1) % len(files)
+            idx = (idx + 1) % len(indices)
         elif key == 81:  # Left arrow
-            idx = (len(files) + idx - 1) % len(files)
+            idx = (len(indices) + idx - 1) % len(indices)
         else:
             print(f'Unrecognized keycode "{key}"')

--- a/scripts/visualize_dataset.py
+++ b/scripts/visualize_dataset.py
@@ -1,0 +1,40 @@
+import cv2
+import numpy as np
+
+from argparse import ArgumentParser
+from pathlib  import Path
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='Interactive visualization of CALVIN dataset')
+    parser.add_argument('path', type=str, help='Path to dir containing scene_info.npy')
+    parser.add_argument('-d', '--data', nargs='*', default=['rgb_static', 'rgb_gripper'], help='Data to visualize')
+    args = parser.parse_args()
+
+    if not Path(args.path).is_dir():
+        print(f'Path {args.path} is either not a directory, or does not exist.')
+        exit()
+
+    files = sorted(Path(args.path).glob('episode_*.npz'))
+
+    idx = 0
+
+    while True:
+        t = np.load(files[idx], allow_pickle=True)
+
+        for d in args.data:
+            if d not in t:
+                print(f'Data {d} cannot be found in transition')
+                continue
+            
+            cv2.imshow(d, t[d])
+        
+        key = cv2.waitKey(0)
+        if key == ord('q'):
+            break
+        elif key == 83: #  Right arrow or p
+            idx = (idx + 1) % len(files)
+        elif key == 81: #  Left arrow or o
+            idx = (len(files) + idx - 1) % len(files)
+        else:
+            print(f'Unrecognized keycode "{key}"')


### PR DESCRIPTION
In reference to #20 I submit this very rudimentary visualization script. It simply finds all the episode files from a given folder and then allows the user to scrub through the data with the arrow keys. Could benefit from a `tqdm` indicator for where one is in a dataset and from keys to skip larger parts.