### PR TITLE
Can we use mmh3 instead of pyhash?

### DIFF
--- a/calvin_models/calvin_agent/datasets/base_dataset.py
+++ b/calvin_models/calvin_agent/datasets/base_dataset.py
@@ -12,11 +12,10 @@ from calvin_agent.datasets.utils.episode_utils import (
 )
 import numpy as np
 from omegaconf import DictConfig
-import pyhash
+import mmh3
 import torch
 from torch.utils.data import Dataset
 
-hasher = pyhash.fnv1_32()
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +32,7 @@ def get_validation_window_size(idx: int, min_window_size: int, max_window_size: 
         Window size computed with hash function.
     """
     window_range = max_window_size - min_window_size + 1
-    return min_window_size + hasher(str(idx)) % window_range
+    return min_window_size + mmh3.hash(str(idx)) % window_range
 
 
 class BaseDataset(Dataset):

--- a/calvin_models/calvin_agent/evaluation/utils.py
+++ b/calvin_models/calvin_agent/evaluation/utils.py
@@ -13,10 +13,9 @@ import hydra
 import numpy as np
 from numpy import pi
 from omegaconf import OmegaConf
-import pyhash
+import mmh3
 import torch
 
-hasher = pyhash.fnv1_32()
 logger = logging.getLogger(__name__)
 
 
@@ -232,7 +231,7 @@ def get_env_state_for_initial_condition(initial_condition):
         np.array([2.29995412e-01, -1.19995140e-01, 4.59990010e-01]),
     ]
     # we want to have a "deterministic" random seed for each initial condition
-    seed = hasher(str(initial_condition.values()))
+    seed = mmh3.hash(str(initial_condition.values()))
     with temp_seed(seed):
         np.random.shuffle(block_table)
 

--- a/calvin_models/requirements.txt
+++ b/calvin_models/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 opencv-python
 omegaconf
 plotly
-pyhash
+mmh3
 pytorch-lightning==1.8.6
 lightning_lite
 torch==1.13.1


### PR DESCRIPTION
Can we use mmh3 instead of pyhash?

It's still difficult to install pyhash in Google Colab. My script:

# Switch to python3.8
!apt-get update -y
!apt-get install python3.8 python3.8-distutils
!update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
!update-alternatives --config python3
!apt-get install python3-pip
!python3 -m pip install --upgrade pip --user

# Install pyhash
!pip install setuptools==57.5
!pip install pyhash

But I still get

Collecting pyhash
  Downloading pyhash-0.9.3.tar.gz (602 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 602.3/602.3 kB 6.7 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: pyhash
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  Building wheel for pyhash (setup.py) ... error
  ERROR: Failed building wheel for pyhash
  Running setup.py clean for pyhash
Failed to build pyhash
ERROR: Could not build wheels for pyhash, which is required to install pyproject.toml-based projects

By contrast, using mmh3 makes my life much easier!
